### PR TITLE
retroactive support for iOS 18

### DIFF
--- a/CommonsFinder.xcodeproj/project.pbxproj
+++ b/CommonsFinder.xcodeproj/project.pbxproj
@@ -193,7 +193,7 @@
 				Views/CategoryView/RelatedCategoryView.swift,
 				Views/ContextMenus/CategoryContextMenu.swift,
 				Views/ContextMenus/MediaFileContextMenu.swift,
-				Views/Extensions/File.swift,
+				"Views/Extensions/MediaFile+localizedDisplayCaption.swift",
 				Views/FileCreateView/FileCreateView.swift,
 				Views/FileCreateView/FilenameTip.swift,
 				Views/FileCreateView/LicensePicker.swift,
@@ -219,6 +219,8 @@
 				Views/Home/HorizontalUploadsSection.swift,
 				Views/Home/HorizontalWikiItemListSection.swift,
 				Views/Home/WelcomeTip.swift,
+				Views/iOS18FallbackSupport/FallbackButtonRoles.swift,
+				Views/iOS18FallbackSupport/GlassFallbackButtonStyle.swift,
 				Views/Map/ClusterAnnotation.swift,
 				Views/Map/GeoClustering/GeoClustering.swift,
 				"Views/Map/GeoClustering/H3+Convenience.swift",
@@ -600,7 +602,7 @@
 				INFOPLIST_FILE = CommonsFinderShareExtension/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = CommonsFinderShareExtension;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -631,7 +633,7 @@
 				INFOPLIST_FILE = CommonsFinderShareExtension/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = CommonsFinderShareExtension;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -826,7 +828,7 @@
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
@@ -884,7 +886,7 @@
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
@@ -911,7 +913,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.nylkiway.CommonsFinderTests;
@@ -935,7 +937,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.nylkiway.CommonsFinderTests;

--- a/CommonsFinder/Generic Extensions/FileNameType+generateFilename.swift
+++ b/CommonsFinder/Generic Extensions/FileNameType+generateFilename.swift
@@ -57,15 +57,12 @@ nonisolated
 {
     var geoString: String?
     if let coordinate {
+        let location = CLLocation(
+            latitude: coordinate.latitude,
+            longitude: coordinate.longitude
+        )
         do {
-            let reverseRequest = MKReverseGeocodingRequest(
-                location: .init(
-                    latitude: coordinate.latitude,
-                    longitude: coordinate.longitude
-                ))
-            let mapItems = try await reverseRequest?.mapItems
-            geoString = mapItems?.first?.address?.shortAddress ?? mapItems?.first?.name
-
+            geoString = try await coordinate.generateHumanReadableString()
         } catch {
             logger.warning("Failed to reverse geo location")
         }

--- a/CommonsFinder/Localizable.xcstrings
+++ b/CommonsFinder/Localizable.xcstrings
@@ -464,7 +464,6 @@
 
     },
     "Console" : {
-      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {

--- a/CommonsFinder/Views/AuthView/LoginView.swift
+++ b/CommonsFinder/Views/AuthView/LoginView.swift
@@ -113,7 +113,7 @@ struct LoginView: View {
                 }
             }
         }
-        .buttonStyle(.glass)
+        .glassButtonStyle()
         .animation(.default, value: model.isPerformingLogin)
         //            .textFieldStyle(OutlinedTextFieldStyle())
         #if !os(macOS)

--- a/CommonsFinder/Views/AuthView/OnboardingView.swift
+++ b/CommonsFinder/Views/AuthView/OnboardingView.swift
@@ -43,7 +43,7 @@ struct OnboardingView: View {
 
             Spacer()
         }
-        .buttonStyle(.glass)
+        .glassButtonStyle()
         .scenePadding(.horizontal)
         .navigationTitle("Wikimedia Account")
         .navigationBarTitleDisplayMode(.inline)

--- a/CommonsFinder/Views/Extensions/MediaFile+localizedDisplayCaption.swift
+++ b/CommonsFinder/Views/Extensions/MediaFile+localizedDisplayCaption.swift
@@ -1,10 +1,11 @@
-import CommonsAPI
 //
 //  File.swift
 //  CommonsFinder
 //
 //  Created by Tom Brewe on 31.05.25.
 //
+
+import CommonsAPI
 import SwiftUI
 
 extension MediaFile {

--- a/CommonsFinder/Views/FileCreateView/FileCreateView.swift
+++ b/CommonsFinder/Views/FileCreateView/FileCreateView.swift
@@ -84,17 +84,30 @@ struct FileCreateView: View {
 
                         Spacer()
                     }
-                    .buttonStyle(.glass)
+                    .glassButtonStyle()
                     .padding()
 
                 } else if model.editedDrafts.count == 1, let selectedID = model.selectedID, let singleSelectedModel = model.editedDrafts[selectedID] {
 
 
-                    MetadataEditForm(model: singleSelectedModel)
-                        .safeAreaBar(edge: .top) {
-                            singleImageView(model: singleSelectedModel)
+                    if #available(iOS 26.0, *) {
+                        MetadataEditForm(model: singleSelectedModel)
+                            .safeAreaBar(edge: .top) {
+                                singleImageView(model: singleSelectedModel)
+                                    .padding(.bottom)
+                            }
+                    } else {
+                        MetadataEditForm(model: singleSelectedModel)
+                            .safeAreaInset(edge: .top) {
+                                HStack {
+                                    Spacer(minLength: 0)
+                                    singleImageView(model: singleSelectedModel)
+                                    Spacer(minLength: 0)
+                                }
+                                .background(Material.ultraThin.opacity(0.92))
                                 .padding(.bottom)
-                        }
+                            }
+                    }
 
 
                 } else if model.editedDrafts.count > 1 {
@@ -168,7 +181,7 @@ struct FileCreateView: View {
     @ToolbarContentBuilder
     private var toolbarContent: some ToolbarContent {
         ToolbarItem(placement: .navigation) {
-            Button("Close", systemImage: "xmark", role: .close) {
+            Button("Close", systemImage: "xmark", role: .fallbackClose) {
                 if model.editedDrafts.isEmpty {
                     dismiss()
                 } else if model.draftsExistInDB {
@@ -184,7 +197,7 @@ struct FileCreateView: View {
                 isPresented: $isShowingCloseConfirmationDialog,
                 titleVisibility: .visible
             ) {
-                Button("Save Draft", systemImage: "square.and.arrow.down", role: .confirm) {
+                Button("Save Draft", systemImage: "square.and.arrow.down", role: .fallbackConfirm) {
                     saveChanges()
                     dismiss()
                 }
@@ -217,7 +230,7 @@ struct FileCreateView: View {
                     isShowingUploadDialog = true
                 }
                 .confirmationDialog("Start upload to Wikimedia Commons now?", isPresented: $isShowingUploadDialog, titleVisibility: .visible) {
-                    Button("Upload", systemImage: "square.and.arrow.up", role: .confirm) {
+                    Button("Upload", systemImage: "square.and.arrow.up", role: .fallbackConfirm) {
                         guard let username = account.activeUser?.username else {
                             assertionFailure()
                             return

--- a/CommonsFinder/Views/FileCreateView/LicensePicker.swift
+++ b/CommonsFinder/Views/FileCreateView/LicensePicker.swift
@@ -40,7 +40,7 @@ struct LicensePicker: View {
                 }
 
                 ToolbarItem(placement: .confirmationAction) {
-                    Button("Close", systemImage: "checkmark", role: .confirm, action: dismiss.callAsFunction)
+                    Button("Close", systemImage: "checkmark", role: .fallbackConfirm, action: dismiss.callAsFunction)
                 }
             }
             .frame(minHeight: 0, maxHeight: .infinity)

--- a/CommonsFinder/Views/FileCreateView/TagPicker/TagPicker.swift
+++ b/CommonsFinder/Views/FileCreateView/TagPicker/TagPicker.swift
@@ -287,7 +287,7 @@ private struct WrappedTagPicker: View {
                         }
                         .labelStyle(.iconOnly)
                         .buttonBorderShape(.circle)
-                        .buttonStyle(.glass)
+                        .glassButtonStyle()
                     }
                 }
 

--- a/CommonsFinder/Views/FileDetailView/FullscreenImageView/FullscreenImageView.swift
+++ b/CommonsFinder/Views/FileDetailView/FullscreenImageView/FullscreenImageView.swift
@@ -167,7 +167,7 @@ struct FullscreenImageView: View {
                                 .frame(width: 26, height: 34)
                         }
                         .labelStyle(.iconOnly)
-                        .buttonStyle(.glass)
+                        .glassButtonStyle()
                         .transition(.blurReplace)
                         .padding(.horizontal)
                     }
@@ -185,7 +185,7 @@ struct FullscreenImageView: View {
                                 .contentTransition(.numericText(value: zoom))
                                 .frame(height: 34)
                         }
-                        .buttonStyle(.glass)
+                        .glassButtonStyle()
                         .padding(.horizontal)
                     }
                 }

--- a/CommonsFinder/Views/FileDetailView/InlineMap.swift
+++ b/CommonsFinder/Views/FileDetailView/InlineMap.swift
@@ -105,13 +105,7 @@ struct InlineMap: View {
         .task {
             do {
                 if knownName == nil {
-                    let request = MKReverseGeocodingRequest(location: .init(latitude: coordinate.latitude, longitude: coordinate.longitude))
-
-
-                    if let item = try await request?.mapItems.first {
-                        geoReversedLabel = item.address?.shortAddress ?? item.name
-                    }
-
+                    geoReversedLabel = try await coordinate.generateHumanReadableString()
                 }
             } catch {
 

--- a/CommonsFinder/Views/Map/MapPopup/MapPopup.swift
+++ b/CommonsFinder/Views/Map/MapPopup/MapPopup.swift
@@ -80,7 +80,7 @@ struct MapPopup: View {
                 Button("Close", systemImage: "xmark") {
                     isPresented = false
                 }
-                .buttonStyle(.glass)
+                .glassButtonStyle()
                 .labelStyle(.iconOnly)
             }
             .padding([.top, .trailing])
@@ -287,25 +287,4 @@ struct PlatterContainer<Content: View>: View {
         //            .background(shape.fill(.background))
     }
     var shape: RoundedRectangle { RoundedRectangle(cornerRadius: 44) }
-}
-
-
-#Preview {
-    PlatterContainer {
-        ConcentricRectangle().fill(.red)
-        ConcentricRectangle().fill(.blue)
-
-        HStack {
-            Group {
-                ConcentricRectangle(corners: .concentric, isUniform: true).fill(.yellow)
-
-                ConcentricRectangle(corners: .concentric, isUniform: true).fill(.yellow)
-            }
-            .padding()
-        }
-        .background(ConcentricRectangle(corners: .concentric, isUniform: true).fill(.red))
-
-    }
-
-
 }

--- a/CommonsFinder/Views/Map/MapView.swift
+++ b/CommonsFinder/Views/Map/MapView.swift
@@ -67,7 +67,7 @@ struct MapView: View {
 
                 }
                 .tint(.blue)
-                .buttonStyle(.glass)
+                .glassButtonStyle()
                 .labelStyle(.iconOnly)
                 .scenePadding()
 

--- a/CommonsFinder/Views/Reusable Views/DraftFileListItem.swift
+++ b/CommonsFinder/Views/Reusable Views/DraftFileListItem.swift
@@ -30,7 +30,6 @@ struct DraftFileListItem: View {
         lazy var uploadStatus = uploadManager.uploadStatus[draft.id]
         let isUploading = uploadStatus != nil
         let canUpload = (account.activeUser != nil) && draft.canUpload && !isUploading
-        let disabled = account.activeUser == nil || uploadStatus != nil
 
         Button {
             navigationModel.editDrafts(drafts: [draft])
@@ -94,10 +93,10 @@ struct DraftFileListItem: View {
                     }
                 }
             }
-            .buttonStyle(.glass)
+            .glassButtonStyle()
             .padding()
         }
-        .disabled(disabled)
+        .disabled(isUploading)
         .overlay {
             uploadProgressOverlay
         }
@@ -208,13 +207,13 @@ struct DraftFileListItem: View {
             isShowingErrorSheet = true
         } label: {
             Label("upload failed", systemImage: "exclamationmark.triangle.fill")
-                .glassEffect()
+                .fallbackGlassEffect()
                 .symbolRenderingMode(.hierarchical)
 
         }
         .transition(.blurReplace.animation(.bouncy))
         .foregroundStyle(.primary)
-        .buttonStyle(.glass)
+        .glassButtonStyle()
     }
 }
 

--- a/CommonsFinder/Views/Reusable Views/UploadErrorDetailsSheet.swift
+++ b/CommonsFinder/Views/Reusable Views/UploadErrorDetailsSheet.swift
@@ -100,7 +100,7 @@ private struct UploadErrorDetailsSheet: View {
             }
 
             ToolbarItem(placement: .cancellationAction) {
-                Button(role: .close, action: dismiss.callAsFunction)
+                Button("Close", role: .fallbackClose, action: dismiss.callAsFunction)
             }
         }
 
@@ -112,7 +112,7 @@ private struct UploadErrorDetailsSheet: View {
     Button("show error sheet") {
         isPresented = true
     }
-    .buttonStyle(.glass)
+    .glassButtonStyle()
     .uploadErrorDetailsSheet(
         .uploadWarnings([.duplicate, .badfilename]),
         isPresented: $isPresented
@@ -125,7 +125,7 @@ private struct UploadErrorDetailsSheet: View {
     Button("show error sheet") {
         isPresented = true
     }
-    .buttonStyle(.glass)
+    .glassButtonStyle()
     .uploadErrorDetailsSheet(
         .uploadWarnings([.duplicate]),
         isPresented: $isPresented
@@ -137,7 +137,7 @@ private struct UploadErrorDetailsSheet: View {
     Button("show error sheet") {
         isPresented = true
     }
-    .buttonStyle(.glass)
+    .glassButtonStyle()
     .uploadErrorDetailsSheet(
         .twoFactorCodeRequired,
         isPresented: $isPresented
@@ -149,7 +149,7 @@ private struct UploadErrorDetailsSheet: View {
     Button("show error sheet") {
         isPresented = true
     }
-    .buttonStyle(.glass)
+    .glassButtonStyle()
     .uploadErrorDetailsSheet(
         .unspecifiedError(PreviewDebugError.httpRequestDenied),
         isPresented: $isPresented

--- a/CommonsFinder/Views/Search/SearchView.swift
+++ b/CommonsFinder/Views/Search/SearchView.swift
@@ -178,12 +178,12 @@ struct SearchView: View {
                 }
                 .padding(.horizontal, 11)
                 .padding(.vertical, 9)
-                .buttonStyle(.glass)
+                .glassButtonStyle()
                 //                .background(.regularMaterial, in: .capsule)
 
                 .font(.footnote)
                 .frame(minWidth: 100)
-                .glassEffect(in: .capsule)
+                .fallbackGlassEffect(in: .capsule)
                 .scenePadding(.horizontal)
                 .padding(.vertical, 5)
                 .padding(.top, isScrolledDown ? 5 : 0)

--- a/CommonsFinder/Views/iOS18FallbackSupport/FallbackButtonRoles.swift
+++ b/CommonsFinder/Views/iOS18FallbackSupport/FallbackButtonRoles.swift
@@ -1,0 +1,26 @@
+//
+//  FallbackButtonRole.swift
+//  CommonsFinder
+//
+//  Created by Tom Brewe on 07.10.25.
+//
+
+import SwiftUI
+
+extension ButtonRole {
+    static var fallbackClose: Self {
+        if #available(iOS 26.0, *) {
+            ButtonRole.close
+        } else {
+            ButtonRole.cancel
+        }
+    }
+
+    static var fallbackConfirm: Self? {
+        if #available(iOS 26.0, *) {
+            ButtonRole.confirm
+        } else {
+            nil
+        }
+    }
+}

--- a/CommonsFinder/Views/iOS18FallbackSupport/GlassFallbackButtonStyle.swift
+++ b/CommonsFinder/Views/iOS18FallbackSupport/GlassFallbackButtonStyle.swift
@@ -1,0 +1,61 @@
+//
+//  GlassFallbackButtonStyle.swift
+//  CommonsFinder
+//
+//  Created by Tom Brewe on 07.10.25.
+//
+
+import SwiftUI
+
+extension View {
+    @ViewBuilder
+    func glassButtonStyle() -> some View {
+        if #available(iOS 26.0, *) {
+            buttonStyle(.glass)
+        } else {
+            buttonStyle(GlassFallbackButtonStyle())
+        }
+    }
+}
+
+extension View {
+    @ViewBuilder
+    func fallbackGlassEffect() -> some View {
+        if #available(iOS 26.0, *) {
+            glassEffect()
+        } else {
+            background(.regularMaterial)
+        }
+    }
+
+    @ViewBuilder
+    func fallbackGlassEffect(in shape: some Shape) -> some View {
+        if #available(iOS 26.0, *) {
+            glassEffect(in: shape)
+        } else {
+            background(.regularMaterial, in: shape)
+                .clipShape(shape)
+                .contentShape(Capsule())
+        }
+    }
+}
+
+
+private struct GlassFallbackButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .padding(.vertical, 5)
+            .padding(.horizontal, 10)
+            .background(.regularMaterial, in: Capsule())
+            .clipShape(Capsule())
+            .contentShape(Capsule())
+            .opacity(configuration.isPressed ? 0.5 : 1)
+    }
+}
+
+#Preview {
+    Button(action: { print("Pressed") }) {
+        Label("Press Me", systemImage: "star")
+    }
+    .buttonStyle(GlassFallbackButtonStyle())
+}


### PR DESCRIPTION
This MR restores iOS 18 support, as it is still installed in a large user base. However the development focus is on iOS 26 which will most likely become the minimum version in an AppStore release version of this app, because I consider the background upload support (BGContinuedProcessingTask) to be essential for batch uploads, once I get around to that feature :)




