### PR TITLE
fix: correctly schedule BGContinuedProcessingTask

### DIFF
--- a/CommonsFinder/ContentView.swift
+++ b/CommonsFinder/ContentView.swift
@@ -80,13 +80,13 @@ struct ContentView: View {
                 accountModel.syncUserData()
             }
         }
-        .onReceive(uploadManager.didFinishUpload) { filename in
+        .onReceive(uploadManager.didFinishUpload) { draftID in
             accountModel.syncUserData()
 
             Task {
                 // We want to give the user some time to realize that the file has been uploaded, via the green checkmark etc.
                 try? await Task.sleep(for: .milliseconds(2000))
-                accountModel.removeUploadedDrafts(filenames: [filename])
+                accountModel.removeUploadedDrafts(ids: [draftID])
             }
         }
     }

--- a/CommonsFinder/Database/AppDatabase.swift
+++ b/CommonsFinder/Database/AppDatabase.swift
@@ -723,11 +723,18 @@ extension AppDatabase {
     }
 
     /// Deletes all files by finalFilename, returns the number of deleted files
-    func deleteDrafts(withFinalFilenames filenames: [String]) throws -> Int {
+    //    func deleteDrafts(withFinalFilenames filenames: [String]) throws -> Int {
+    //        try dbWriter.write { db in
+    //            try MediaFileDraft
+    //                //                .filter(filenames.contains(MediaFileDraft.Columns.finalFilename))
+    //                .deleteAll(db)
+    //        }
+    //    }
+    //
+    func deleteDrafts(ids: [MediaFileDraft.ID]) throws -> Int {
         try dbWriter.write { db in
             try MediaFileDraft
-                //                .filter(filenames.contains(MediaFileDraft.Columns.finalFilename))
-                .deleteAll(db)
+                .deleteAll(db, ids: ids)
         }
     }
 }

--- a/CommonsFinder/Info.plist
+++ b/CommonsFinder/Info.plist
@@ -4,7 +4,7 @@
 <dict>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
-		<string>app.CommonsFinder.upload</string>
+		<string>app.CommonsFinder.upload.*</string>
 	</array>
 	<key>CFBundleURLTypes</key>
 	<array>

--- a/CommonsFinder/Observable Models/UploadManager/MockUploadManager.swift
+++ b/CommonsFinder/Observable Models/UploadManager/MockUploadManager.swift
@@ -27,60 +27,60 @@ final class MockUploadManager: UploadManager {
         super.init(appDatabase: appDatabase)
     }
 
-    private func simulateRegularUpload(_ uploadable: MediaFileUploadable) {
+    private func simulateRegularUpload(_ id: MediaFileDraft.ID) {
         print("simulateRegularUpload")
         Task {
             try? await Task.sleep(for: .milliseconds(100))
-            uploadStatus[uploadable.id] = .uploading(0.01)
+            uploadStatus[id] = .uploading(0.01)
 
             try? await Task.sleep(for: .milliseconds(500))
-            uploadStatus[uploadable.id] = .uploading(0.1)
+            uploadStatus[id] = .uploading(0.1)
 
             try? await Task.sleep(for: .milliseconds(500))
-            uploadStatus[uploadable.id] = .uploading(0.2)
+            uploadStatus[id] = .uploading(0.2)
 
             try? await Task.sleep(for: .milliseconds(500))
-            uploadStatus[uploadable.id] = .uploading(0.5)
+            uploadStatus[id] = .uploading(0.5)
 
             try? await Task.sleep(for: .milliseconds(500))
-            uploadStatus[uploadable.id] = .uploading(0.8)
+            uploadStatus[id] = .uploading(0.8)
 
             try? await Task.sleep(for: .milliseconds(500))
-            uploadStatus[uploadable.id] = .uploading(1)
+            uploadStatus[id] = .uploading(1)
             try? await Task.sleep(for: .milliseconds(500))
-            uploadStatus[uploadable.id] = .unstashingFile
+            uploadStatus[id] = .unstashingFile
 
             try? await Task.sleep(for: .milliseconds(600))
-            uploadStatus[uploadable.id] = .creatingWikidataClaims
+            uploadStatus[id] = .creatingWikidataClaims
 
             try? await Task.sleep(for: .milliseconds(600))
-            uploadStatus[uploadable.id] = .published
+            uploadStatus[id] = .published
             try? await Task.sleep(for: .milliseconds(1000))
         }
     }
 
-    private func simulateErrorUpload(_ uploadable: MediaFileUploadable) {
+    private func simulateErrorUpload(_ id: MediaFileDraft.ID) {
         print("simulateErrorUpload")
         Task {
             try? await Task.sleep(for: .milliseconds(100))
-            uploadStatus[uploadable.id] = .uploading(0.01)
+            uploadStatus[id] = .uploading(0.01)
 
             try? await Task.sleep(for: .milliseconds(500))
-            uploadStatus[uploadable.id] = .uploading(0.1)
+            uploadStatus[id] = .uploading(0.1)
 
             try? await Task.sleep(for: .milliseconds(1000))
-            uploadStatus[uploadable.id] = .uploadWarnings([.existsNormalized(normalizedName: "Some-similar-name.jpeg")])
+            uploadStatus[id] = .uploadWarnings([.existsNormalized(normalizedName: "Some-similar-name.jpeg")])
         }
     }
 
-    override func performUpload(_ uploadable: MediaFileUploadable) {
+    override func performUpload(_ id: MediaFileDraft.ID) {
         print("perform simulated upload")
         switch uploadMockSimulation {
         case .regular:
-            simulateRegularUpload(uploadable)
-            didFinishUpload.send(uploadable.filename)
+            simulateRegularUpload(id)
+            didFinishUpload.send(id)
         case .withErrors:
-            simulateErrorUpload(uploadable)
+            simulateErrorUpload(id)
         }
     }
 }

--- a/CommonsFinder/Views/Map/MapSheet/MapSheetToolbar.swift
+++ b/CommonsFinder/Views/Map/MapSheet/MapSheetToolbar.swift
@@ -44,7 +44,7 @@ struct MapSheetToolbar: ToolbarContent {
             if let model = (model as? MapItemWithSubItems), model.maxCount > 1 {
                 CounterView(current: (model.focusedIdx ?? 0) + 1, max: model.maxCount)
             } else if #available(iOS 26.0, *) {
-                
+
             } else {
                 Color.clear.frame(width: 70)
             }


### PR DESCRIPTION
per id instead of re-registering the same BGTask ID

This fixes a crash that occurs when uploading more than 1 file per session on iOS26

 fixes #50