### PR TITLE
feat(FileDetailView): button to copy the filename

### DIFF
--- a/CommonsFinder/Localizable.xcstrings
+++ b/CommonsFinder/Localizable.xcstrings
@@ -604,6 +604,16 @@
         }
       }
     },
+    "Copy Filename" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dateinamen kopieren"
+          }
+        }
+      }
+    },
     "Copy ID" : {
       "localizations" : {
         "de" : {

--- a/CommonsFinder/Views/FileDetailView/FileDetailView.swift
+++ b/CommonsFinder/Views/FileDetailView/FileDetailView.swift
@@ -159,11 +159,22 @@ struct FileDetailView: View {
                             navigation.showOnMap(mediaFile: mediaFileInfo.mediaFile, mapModel: mapModel)
                         }
 
+                        Divider()
+
                         ShareLink(item: mediaFileInfo.mediaFile.descriptionURL)
 
                         Link(destination: mediaFileInfo.mediaFile.descriptionURL) {
                             Label("Open in Browser", systemImage: "globe")
                         }
+
+                        Button {
+                            UIPasteboard.general.string = mediaFileInfo.mediaFile.name
+                        } label: {
+                            Image(systemName: "clipboard")
+                            Text("Copy Filename")
+                            Text(mediaFileInfo.mediaFile.name)
+                        }
+
                     } label: {
                         Image(systemName: "ellipsis")
                             .font(.title2)


### PR DESCRIPTION
This adds a button to the menu in the FileDetailView to copy the filename of the viewed image.
resolves #56 