### PR TITLE
fix: only full refresh media file if revid changed

### DIFF
--- a/CommonsAPI/Sources/CommonsAPI/API.swift
+++ b/CommonsAPI/Sources/CommonsAPI/API.swift
@@ -1048,6 +1048,26 @@ LIMIT \(limit)
         return result[filename]
     }
     
+    public func fetchMostRecentRevid(pageID: String) async throws -> Int? {
+        let query: Parameters = [
+            "action": "query",
+            "format": "json",
+            "prop": "revisions",
+            "rvslots": "main",
+            "rvprop": "ids",
+            "rvlimit": "1",
+            "pageids": pageID,
+            "formatversion": "2",
+            "curtimestamp": "1"
+        ]
+        
+        let request = try GET(url: commonsEndpoint, query: query)
+        let (data, response) = try await response(for: request)
+        let parsedResponse = try parse(QueryResponse<PageRevisionsResponse>.self, from: data, response: response)
+        
+        return parsedResponse.query?.pages.first?.revisions?.first?.revid
+    }
+    
     /// Check if a media file already exists by filename, returns [filename: FilenameExistsResult]
     public func checkIfFilesExists(filenames: [String]) async throws -> [String: FilenameExistsResult] {
         let titles = filenames.map { "File:" + $0 }

--- a/CommonsAPI/Sources/CommonsAPI/Types/Decodable Types/Decodable Types.swift
+++ b/CommonsAPI/Sources/CommonsAPI/Types/Decodable Types/Decodable Types.swift
@@ -224,8 +224,6 @@ public struct FileUploadResponse: Decodable, Sendable {
             self.filename = try container.decodeIfPresent(String.self, forKey: FileUploadResponse.Upload.CodingKeys.filename)
             self.filekey = try container.decodeIfPresent(String.self, forKey: FileUploadResponse.Upload.CodingKeys.filekey)
             
-
-
             let stringWarningsDict: [String: String]? = try? container.decodeIfPresent([String: String].self, forKey: FileUploadResponse.Upload.CodingKeys.warnings)
             let arrayWarningsDict: [String: [String]]? = try? container.decodeIfPresent([String: [String]].self, forKey: FileUploadResponse.Upload.CodingKeys.warnings)
             if let stringWarningsDict {
@@ -937,6 +935,8 @@ internal struct PageRevisionsResponse: Decodable, Sendable {
         let revisions: [Revision]?
 
         struct Revision: Decodable, Sendable {
+            let revid: Int?
+            let parentid: Int?
             let slots: Slots?
 
             struct Slots: Decodable, Sendable {

--- a/CommonsFinder/DataFetching/DataAccess.swift
+++ b/CommonsFinder/DataFetching/DataAccess.swift
@@ -18,6 +18,28 @@ typealias ScoredCategoryInfo = (score: Double, categoryInfo: CategoryInfo)
 /// Provides data access functions to the API or DB
 //  To be refined with more DB-first searches and fetchDate comparisons. (like `fetchCombinedTagsFromDatabaseOrAPI`)
 nonisolated enum DataAccess {
+
+    static func refreshMediaFileIfNeeded(_ mediaFile: MediaFile, maxAge: TimeInterval = 0, appDatabase: AppDatabase) async {
+        let timeIntervalSinceLastFetchDate = Date.now.timeIntervalSince(mediaFile.fetchDate)
+
+        guard timeIntervalSinceLastFetchDate > maxAge else { return }
+
+        do {
+            let isMediaFileUpToDate = try await Self.isMediaFileUpToDate(mediaFile)
+
+            if isMediaFileUpToDate {
+                // consider the media file to have been fetched now since the revid is idential
+                try appDatabase.updateLastFetchedToNow(mediaFile.id)
+            } else {
+                // NOTE: changes from refresh will propagate into the DB observation further above.
+                await DataAccess.refreshMediaFileFromNetwork(id: mediaFile.id, appDatabase: appDatabase)
+            }
+        } catch {
+            logger.error("failed to refreshMediaFileIfNeeded \(mediaFile.name), \(error)")
+            return
+        }
+    }
+
     static func refreshMediaFileFromNetwork(id: MediaFile.ID, appDatabase: AppDatabase) async {
         do {
             guard
@@ -296,7 +318,7 @@ nonisolated enum DataAccess {
         let commonsCategories = mediaFiles.flatMap(\.categories)
 
 
-        let result = try await DataAccess.fetchCombinedCategoriesFromDatabaseOrAPI(
+        let result = try await fetchCombinedCategoriesFromDatabaseOrAPI(
             wikidataIDs: depictWikdataIDs,
             commonsCategories: commonsCategories,
             forceNetworkRefresh: forceNetworkRefresh,
@@ -340,7 +362,7 @@ nonisolated enum DataAccess {
         // TODO: would be easier if fetchCombinedCategoriesFromDatabaseOrAPI already returned [CategoryInfo] instead of Category.
         // but not super trivial due to other dependencies of `CategoryFetchResult`
         let fetchResult =
-            try await DataAccess.fetchCombinedCategoriesFromDatabaseOrAPI(
+            try await fetchCombinedCategoriesFromDatabaseOrAPI(
                 wikidataIDs: searchItems.map(\.id),
                 commonsCategories: searchCategories,
                 forceNetworkRefresh: false,
@@ -385,6 +407,12 @@ nonisolated enum DataAccess {
         }
 
         return result
+    }
+
+    private static func isMediaFileUpToDate(_ mediaFile: MediaFile) async throws -> Bool {
+        guard let revid = mediaFile.revid else { return false }
+        let mostRecentRevid = try await Networking.shared.api.fetchMostRecentRevid(pageID: mediaFile.pageID)
+        return revid == mostRecentRevid
     }
 }
 

--- a/CommonsFinder/Database/AppDatabase.swift
+++ b/CommonsFinder/Database/AppDatabase.swift
@@ -280,10 +280,13 @@ nonisolated final class AppDatabase: Sendable {
                 // make locationHandling optional (for subdrafts of multidrafts)
                 t.drop(column: "locationHandling")
                 t.add(column: "locationHandling", .jsonText)
-
-
             }
+        }
 
+        migrator.registerMigration("add revid to mediaFile") { db in
+            try db.alter(table: "mediaFile") { t in
+                t.add(column: "revid", .integer)
+            }
         }
 
         return migrator
@@ -409,10 +412,17 @@ nonisolated extension AppDatabase {
 }
 
 // MARK: - MediaFileInfo Writes
-extension AppDatabase {
+nonisolated extension AppDatabase {
     /// creates a new DB entry if needed
     func updateLastViewed(_ mediaFileInfo: MediaFileInfo) throws -> MediaFileInfo {
         try updateInteractionImpl(mediaFileInfo, lastViewed: .now, incrementViewCount: true)
+    }
+
+    func updateLastFetchedToNow(_ id: MediaFile.ID) throws {
+        try dbWriter.write { db in
+            var mediaFile = try MediaFile.find(db, id: id)
+            try mediaFile.updateChanges(db) { $0.fetchDate = .now }
+        }
     }
 
     /// creates a new DB entry if needed

--- a/CommonsFinder/Database/Model/Extensions/MediaFile+InitFromAPI.swift
+++ b/CommonsFinder/Database/Model/Extensions/MediaFile+InitFromAPI.swift
@@ -37,6 +37,7 @@ nonisolated
 
         self.init(
             id: String(apiFileMetadata.pageData.pageid),
+            revid: apiFileMetadata.pageData.lastrevid,
             name: apiFileMetadata.pageData.title,
             url: imageInfo.url,
             descriptionURL: imageInfo.descriptionurl,

--- a/CommonsFinder/Database/Model/Extensions/MediaFile+makeRandomUploaded.swift
+++ b/CommonsFinder/Database/Model/Extensions/MediaFile+makeRandomUploaded.swift
@@ -14,6 +14,7 @@ nonisolated extension MediaFile {
         let date: Date = .init(timeIntervalSince1970: 3600 * Double(UInt.random(in: 1..<1234)))
         return MediaFile.init(
             id: id + String(Int64.random(in: 0..<Int64.max)),
+            revid: Int.random(in: 100000...Int.max),
             name: id,
             url: imageType.url,
             descriptionURL: imageType.url,

--- a/CommonsFinder/Database/Model/MediaFile.swift
+++ b/CommonsFinder/Database/Model/MediaFile.swift
@@ -24,6 +24,9 @@ nonisolated
     /// pageID
     var id: String
 
+    /// the revision ID of this version of the file
+    var revid: Int?
+
     /// username of uploader
     var username: String
 
@@ -67,6 +70,7 @@ nonisolated
 
     init(
         id: String,
+        revid: Int? = nil,
         name: String,
         url: URL,
         descriptionURL: URL,
@@ -104,6 +108,7 @@ nonisolated
         }
 
         self.id = id
+        self.revid = revid
         self.url = url
         self.descriptionURL = descriptionURL
         self.thumbURL = thumbURL
@@ -131,6 +136,7 @@ nonisolated extension MediaFile: Codable, FetchableRecord, MutablePersistableRec
     // Define database columns from CodingKeys
     nonisolated enum Columns {
         static let id = Column(CodingKeys.id)
+        static let revid = Column(CodingKeys.revid)
         static let itemInteractionID = Column(CodingKeys.itemInteractionID)
         static let username = Column(CodingKeys.username)
         static let name = Column(CodingKeys.name)

--- a/CommonsFinder/Localizable.xcstrings
+++ b/CommonsFinder/Localizable.xcstrings
@@ -1387,6 +1387,9 @@
         }
       }
     },
+    "Loading newest file version..." : {
+
+    },
     "Location" : {
       "localizations" : {
         "de" : {

--- a/CommonsFinder/Tests/DatabaseTests.swift
+++ b/CommonsFinder/Tests/DatabaseTests.swift
@@ -357,7 +357,7 @@ struct DatabaseTests {
             "At the start, we expect the db to be empty for a clean test."
         )
 
-        let upsertedCategories = try repo.upsert(categories, handleRedirections: redirections)
+        let upsertedCategories = try repo.upsertAndFetchOrdered(categories, handleRedirections: redirections)
         #expect(upsertedCategories.count == categories.count)
 
         let fetchedItemsWithResolvedRedirects = try repo.fetchCategoryInfos(wikidataIDs: wikidataIDs, resolveRedirections: true)

--- a/CommonsFinder/Tests/UploadFilePreparationTests.swift
+++ b/CommonsFinder/Tests/UploadFilePreparationTests.swift
@@ -54,7 +54,7 @@ struct UploadFilePreparationTests {
         var draft = try createSampleDraft(latitude: 48.137, longitude: 11.575)
 
         defer { cleanup(draft) }
-        #expect(draft.loadExifData()?.coordinate != nil, "the imported file must have a coordinate for this test")
+        #expect(draft.loadCachedExifData()?.coordinate != nil, "the imported file must have a coordinate for this test")
 
         // setting `.noLocation` is expected to remove location EXIF data
         draft.locationHandling = .noLocation
@@ -67,7 +67,7 @@ struct UploadFilePreparationTests {
         )
         #expect(FileManager.default.fileExists(atPath: uploadURL.path()), "file to upload should exist")
 
-        #expect(draft.loadExifData()?.coordinate != nil, "original draft file's EXIF should be unchanged")
+        #expect(draft.loadCachedExifData()?.coordinate != nil, "original draft file's EXIF should be unchanged")
 
         let stagingExif = try? ExifData(url: uploadURL)
         #expect(stagingExif?.coordinate == nil, "staging copy has EXIF location data removed")
@@ -95,7 +95,9 @@ struct UploadFilePreparationTests {
 
     @Test("User-defined location writes the chosen coordinate into the staging copy")
     func userDefinedLocationWritesStaging() throws {
-        var draft = try createSampleDraft(latitude: 10, longitude: 10)
+        let sampleLat = 10.0
+        let sampleLon = 11.0
+        var draft = try createSampleDraft(latitude: sampleLat, longitude: sampleLon)
         defer { cleanup(draft) }
 
         // setting `.locationHandling` with latitude, longitude is expected to only use those values for the wikitext and structured data
@@ -106,9 +108,9 @@ struct UploadFilePreparationTests {
 
         #expect(FileManager.default.fileExists(atPath: uploadURL.path()), "file to upload should exist")
 
-        let originalDraftEXIF = draft.loadExifData()?.coordinate
+        let originalDraftEXIFCoordinate = draft.loadCachedExifData()?.coordinate
         #expect(
-            draft.loadExifData()?.coordinate?.latitude == 10 && draft.loadExifData()?.coordinate?.latitude == 10,
+            originalDraftEXIFCoordinate?.latitude == sampleLat && originalDraftEXIFCoordinate?.longitude == sampleLon,
             "original draft file should be untouched."
         )
 

--- a/CommonsFinder/Views/FileDetailView/FileDetailView.swift
+++ b/CommonsFinder/Views/FileDetailView/FileDetailView.swift
@@ -192,7 +192,7 @@ struct FileDetailView: View {
                     logger.error("CAT: Failed to observe MediaFileInfo changes \(error)")
                 }
             }
-            .task(id: mediaFileInfo.mediaFile.fetchDate, priority: .userInitiated) {
+            .task(id: mediaFileInfo.mediaFile.revid, priority: .userInitiated) {
                 isResolvingTags = true
 
                 do {
@@ -213,17 +213,9 @@ struct FileDetailView: View {
                     isResolvingTags = false
                 }
 
-                // After resolving tags, if the file hasn't been refreshed from network in a while (2 minutes)
+                // After resolving tags, if the file hasn't been refreshed from network in a while (1 minutes)
                 // do it now
-
-                let timeIntervalSinceLastFetchDate = Date.now.timeIntervalSince(mediaFileInfo.mediaFile.fetchDate)
-                if timeIntervalSinceLastFetchDate > (2 * 60) {
-                    do {
-                        try await Task.sleep(for: .milliseconds(250))
-                        // NOTE: changes from refresh will propagate into the DB observation further above.
-                        await DataAccess.refreshMediaFileFromNetwork(id: mediaFileInfo.id, appDatabase: appDatabase)
-                    } catch {}
-                }
+                await DataAccess.refreshMediaFileIfNeeded(mediaFileInfo.mediaFile, maxAge: 60, appDatabase: appDatabase)
             }
             .onDisappear {
                 saveFileToLastViewed()

--- a/CommonsFinder/Views/FileEditView/FileEditView.swift
+++ b/CommonsFinder/Views/FileEditView/FileEditView.swift
@@ -72,15 +72,11 @@ struct FileEditView: View {
     }
 
     func refreshIfNeeded() async throws {
-        guard let model else { return }
+        guard let model, !model.hasBeenEdited else { return }
         isRefreshing = true
-        let timeIntervalSinceLastFetchDate = Date.now.timeIntervalSince(model.referenceMediaFileInfo.mediaFile.fetchDate)
-        print("timeIntervalSinceLastFetchDate B: \(timeIntervalSinceLastFetchDate)")
-        if timeIntervalSinceLastFetchDate > (10) {
-            let id = model.referenceMediaFileInfo.id
-            await DataAccess.refreshMediaFileFromNetwork(id: id, appDatabase: appDatabase)
-        }
-        isRefreshing = false
+        defer { isRefreshing = false }
+
+        await DataAccess.refreshMediaFileIfNeeded(model.referenceMediaFileInfo.mediaFile, maxAge: 5, appDatabase: appDatabase)
     }
 
 
@@ -105,9 +101,15 @@ struct FileEditView: View {
                 for try await updatedMediaFileInfo in observation.values(in: appDatabase.reader) {
                     guard let updatedMediaFileInfo else { continue }
                     try Task.checkCancellation()
-                    let tags = try await DataAccess.resolveTags(of: [updatedMediaFileInfo.mediaFile], appDatabase: appDatabase)
-                    model = .init(with: updatedMediaFileInfo, resolvedTags: tags)
-                    try await refreshIfNeeded()
+
+                    do {
+                        let tags = try await DataAccess.resolveTags(of: [updatedMediaFileInfo.mediaFile], appDatabase: appDatabase)
+                        model = .init(with: updatedMediaFileInfo, resolvedTags: tags)
+                        try await refreshIfNeeded()
+                    } catch {
+                        // FIXME: show error in UI
+                        logger.error("edit: failed to refresh media file for editing \(error)")
+                    }
                 }
 
             } catch {


### PR DESCRIPTION
this reduces the amount of network requests and traffic. It does introduce an extra fetch, but the revid fetch is fast and small. In most cases the revid doesn't change that often (only after edits of the file), and opening a file without a change now only calls a single and fast query vs. 2 bigger ones previously.